### PR TITLE
RUN features.sh for AcmeAirEE8 dockerfile

### DIFF
--- a/AcmeAirEE8/LibertyContext/Dockerfile_acmeair
+++ b/AcmeAirEE8/LibertyContext/Dockerfile_acmeair
@@ -6,6 +6,7 @@ FROM open-liberty:kernel-slim-java17-openj9
 COPY --chown=1001:0 LibertyFiles/server.xml /config/server.xml
 COPY --chown=1001:0 LibertyFiles/acmeair-java-2.0.0-SNAPSHOT.war /config/apps/
 EXPOSE 9080
+RUN features.sh
 
 #ENV OPENJ9_SCC=false
 ENV VERBOSE=true


### PR DESCRIPTION
If the liberty application image is based on "kernel", we have to install the required "features" by adding RUN features.sh
to the dockerfile